### PR TITLE
change Hot/JassHelper.hs cleanName()

### DIFF
--- a/Hot/JassHelper.hs
+++ b/Hot/JassHelper.hs
@@ -12,7 +12,7 @@ import Data.Composeable
 
 cleanName :: Name -> Name
 cleanName x =
-  let x' = concatMap (\case '_':'_':_ -> "__"; x -> x) $ group x
+  let x' = concatMap (\case "___" -> "__"; x -> x) $ group x
   in if "jasshelper__init" `isPrefixOf` x
   then "jasshelper__init0000"
   else x'


### PR DESCRIPTION
16fc5a0:
from JassHelperManual.html `Private members` section:
> The way private work is actually by automatically prefixing **scopename(random digit)__** to the identifier names of the private members.

but from JassHelper source code:
```pas
function GetPrivatePrefix():string;
begin
    if (GetPseudoRandom() mod 2 = 0) then begin
        Result := '__' // <--
    end else begin
        Result := '___'; // <--
    end
end;
// ...
procedure newscope(const b : boolean);
begin
    // ...
    libpreffix_private := scope + GetPrivatePrefix(); // <--
    libpreffix_public := scope + '_';
    // ...
end;
// ...
procedure beginLibrary;
begin
    // ...
   newscope(false); // <--
    // ...
end;
```

1f709d9:
add ubuntu 22.04 build section to readme.md