### PR TITLE
fix runtime/alloc.j __BASE_FILE__ macro

### DIFF
--- a/runtime/alloc.j
+++ b/runtime/alloc.j
@@ -9,7 +9,7 @@ function _alloc takes nothing returns integer
     endif
     
     if _this >= JASS_MAX_ARRAY_SIZE then
-        call Print#_print("no more free instances " + "__BASE_FILE__")
+        call Print#_print("no more free instances " + __BASE_FILE__)
         return 0
     endif
 
@@ -19,10 +19,10 @@ endfunction
 
 function _free takes integer _this returns nothing
     if _this == 0 then
-        call Print#_print("free of nullptr " + "__BASE_FILE__")
+        call Print#_print("free of nullptr " + __BASE_FILE__)
         return
     elseif _V[_this] != -1 then
-        call Print#_print("Double free in " + "__BASE_FILE__")
+        call Print#_print("Double free in " + __BASE_FILE__)
         return
     endif
     set _V[_this] = _F


### PR DESCRIPTION
before:
![image](https://github.com/lep/jhcr/assets/38818683/339b50eb-4266-4c3a-a930-e305b04a91ba)
after:
![image](https://github.com/lep/jhcr/assets/38818683/8b5da824-d999-4012-a87e-73f5067dfbfb)
