### PR TITLE
Rewrote the instruction optimizer

### DIFF
--- a/src/Hot/Instruction/Opt/Rewrite/SomeRules.hs
+++ b/src/Hot/Instruction/Opt/Rewrite/SomeRules.hs
@@ -406,6 +406,7 @@ args b n = map (mkRule n)
         in [b, cmd] --> [b]
 
 
+someRules :: [Rule]
 someRules =
        eliminateUselessJmp
     <> eliminateTmpOther

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 import Debug.Trace
 


### PR DESCRIPTION
Uses a sliding window and only touches each (remaining) rule per instruction per window once. Also removes all non-matching rules as early as possible. It's still way too slow but it's useable now for large changesets.

Fixes #9 (for now).